### PR TITLE
YAML Configuration

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: '1.21.3'
 
     - name: Build
       run: go build -v ./...

--- a/data/config/backplane.yaml
+++ b/data/config/backplane.yaml
@@ -1,0 +1,108 @@
+name: sample_device
+
+triggers: triggers
+
+constants: consts
+
+# Network devices
+network_devices:
+  - name: DEVICE_NAME
+    mode: auto
+    port: 8080
+
+# Type Definitions
+type_definitions:
+  AccelerometerData:
+    - name: X
+      size: 4
+      type: float
+    - name: Y
+      size: 4
+      type: float
+    - name: Z
+      size: 4
+      type: float
+
+  BarometerData:
+    - name: Pressure
+      size: 4
+      type: float
+    - name: Temperature
+      size: 4
+      type: float
+
+  GyroscopeData:
+    - name: X
+      size: 4
+      type: float
+    - name: Y
+      size: 4
+      type: float
+    - name: Z
+      size: 4
+      type: float
+
+  MagnetometerData:
+    - name: X
+      size: 4
+      type: float
+    - name: Y
+      size: 4
+      type: float
+    - name: Z
+      size: 4
+      type: float
+
+  ShuntData:
+    - name: Current
+      size: 4
+      type: float
+    - name: Voltage
+      size: 4
+      type: float
+    - name: Power
+      size: 4
+      type: float
+
+  GnssPositioningData:
+    - name: Latitude
+      size: 8
+      type: double
+    - name: Longitude
+      size: 8
+      type: double
+    - name: Altitude
+      size: 4
+      type: float
+
+  TemperatureData:
+    - name: Temperature
+      size: 4
+      type: float
+
+# Measurements
+measurements:
+  - name: ADXL375_X
+    size: 4
+    type: float
+    signed: true
+    endianness: little
+  - name: ADXL375_Y
+    size: 4
+    type: float
+    signed: true
+    endianness: little
+  - name: ADXL375_Z
+    size: 4
+    type: float
+    signed: true
+    endianness: little
+
+# Telemetry packets
+telemetry_packets:
+  - name: SensorModule100Hz
+    port: 10000
+    measurements:
+      - ADXL375_X
+      - ADXL375_Y
+      - ADXL375_Z

--- a/data/config/backplane.yaml
+++ b/data/config/backplane.yaml
@@ -85,17 +85,16 @@ measurements:
   - name: ADXL375_X
     size: 4
     type: float
-    signed: true
-    endianness: little
   - name: ADXL375_Y
     size: 4
     type: float
-    signed: true
-    endianness: little
+    endianness: big
   - name: ADXL375_Z
     size: 4
     type: float
-    signed: true
+  - name: Random
+    type: float
+    unsigned: true
     endianness: little
 
 # Telemetry packets
@@ -106,3 +105,4 @@ telemetry_packets:
       - ADXL375_X
       - ADXL375_Y
       - ADXL375_Z
+      - Random

--- a/data/config/backplane.yaml
+++ b/data/config/backplane.yaml
@@ -1,16 +1,5 @@
-name: sample_device
+name: backplane
 
-triggers: triggers
-
-constants: consts
-
-# Network devices
-network_devices:
-  - name: DEVICE_NAME
-    mode: auto
-    port: 8080
-
-# Type Definitions
 type_definitions:
   AccelerometerData:
     - name: X
@@ -80,7 +69,6 @@ type_definitions:
       size: 4
       type: float
 
-# Measurements
 measurements:
   - name: ADXL375_X
     size: 4
@@ -97,7 +85,6 @@ measurements:
     unsigned: true
     endianness: little
 
-# Telemetry packets
 telemetry_packets:
   - name: SensorModule100Hz
     port: 10000

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/AarC10/GSW-V2
 
 go 1.21.3
+
+require gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/AarC10/GSW-V2
 
 go 1.21.3
 
-require gopkg.in/yaml.v2 v2.4.0 // indirect
+require gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,3 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/main.go
+++ b/main.go
@@ -5,16 +5,6 @@ import (
 	"github.com/AarC10/GSW-V2/proc"
 )
 
-func main() {
-	cfg, err := proc.ParseYAML("data/config/backplane.yaml")
-	if err != nil {
-		fmt.Printf("Error parsing YAML: %v\n", err)
-		return
-	}
-
-	printTelemetryPackets(cfg)
-}
-
 func printTelemetryPackets(cfg *proc.Configuration) {
 	fmt.Println("Telemetry Packets:")
 	for _, packet := range cfg.TelemetryPackets {
@@ -42,4 +32,14 @@ func findMeasurementByName(measurements []proc.Measurement, name string) (*proc.
 		}
 	}
 	return nil, fmt.Errorf("measurement '%s' not found", name)
+}
+
+func main() {
+	cfg, err := proc.ParseYAML("data/config/backplane.yaml")
+	if err != nil {
+		fmt.Printf("Error parsing YAML: %v\n", err)
+		return
+	}
+
+	printTelemetryPackets(cfg)
 }

--- a/main.go
+++ b/main.go
@@ -3,23 +3,43 @@ package main
 import (
 	"fmt"
 	"github.com/AarC10/GSW-V2/proc"
-	"strings"
 )
 
-type Field struct {
-	Type   string `json:"type"`
-	Endian string `json:"endian"`
-}
-
-type Port struct {
-	Fields map[string]Field `json:"fields"`
-}
-
-func printWithTabbing(level int, text string) {
-	fmt.Print(strings.Repeat("\t", level))
-	fmt.Println(text)
-}
-
 func main() {
-	fmt.Println(proc.ParseConfiguration("data/config/test.json"))
+	cfg, err := proc.ParseYAML("data/config/backplane.yaml")
+	if err != nil {
+		fmt.Printf("Error parsing YAML: %v\n", err)
+		return
+	}
+
+	printTelemetryPackets(cfg)
+}
+
+func printTelemetryPackets(cfg *proc.Configuration) {
+	fmt.Println("Telemetry Packets:")
+	for _, packet := range cfg.TelemetryPackets {
+		fmt.Printf("\tName: %s\n\tPort: %d\n", packet.Name, packet.Port)
+		if len(packet.Measurements) > 0 {
+			fmt.Println("\tMeasurements:")
+			for _, measurementName := range packet.Measurements {
+				measurement, err := findMeasurementByName(cfg.Measurements, measurementName)
+				if err != nil {
+					fmt.Printf("\t\tMeasurement '%s' not found: %v\n", measurementName, err)
+					continue
+				}
+				fmt.Printf("\t\t%s\n", measurement.String())
+			}
+		} else {
+			fmt.Println("\t\tNo measurements defined.")
+		}
+	}
+}
+
+func findMeasurementByName(measurements []proc.Measurement, name string) (*proc.Measurement, error) {
+	for _, m := range measurements {
+		if m.Name == name {
+			return &m, nil
+		}
+	}
+	return nil, fmt.Errorf("measurement '%s' not found", name)
 }

--- a/proc/vcm.go
+++ b/proc/vcm.go
@@ -17,7 +17,7 @@ type Measurement struct {
 	Name       string `yaml:"name"`
 	Size       int    `yaml:"size"`
 	Type       string `yaml:"type,omitempty"`
-	Signed     bool   `yaml:"signed,omitempty"`
+	Unsigned   bool   `yaml:"unsigned,omitempty"`
 	Endianness string `yaml:"endianness,omitempty"`
 }
 
@@ -39,6 +39,19 @@ func ParseYAML(filename string) (*Configuration, error) {
 		return nil, fmt.Errorf("error parsing YAML: %v", err)
 	}
 
+	// Set default values for measurements if not specified
+	for i := range cfg.Measurements {
+		if cfg.Measurements[i].Name == "" {
+			return nil, fmt.Errorf("Measurement name missing")
+		}
+
+		if cfg.Measurements[i].Endianness == "" {
+			cfg.Measurements[i].Endianness = "big" // Default to big endian
+		} else if cfg.Measurements[i].Endianness != "little" && cfg.Measurements[i].Endianness != "big" {
+			return nil, fmt.Errorf("Endianess not specified as big or little got %s", cfg.Measurements[i].Endianness)
+		}
+	}
+
 	return &cfg, nil
 }
 
@@ -48,10 +61,11 @@ func (m Measurement) String() string {
 	if m.Type != "" {
 		sb.WriteString(fmt.Sprintf(", Type: %s", m.Type))
 	}
-	if m.Signed {
-		sb.WriteString(", Signed")
-	} else {
+
+	if m.Unsigned {
 		sb.WriteString(", Unsigned")
+	} else {
+		sb.WriteString(", Signed")
 	}
 	sb.WriteString(fmt.Sprintf(", Endianness: %s", m.Endianness))
 	return sb.String()


### PR DESCRIPTION
Use YAML instead of JSON for easier readability. YAML configs should be moved to NSW once we have an autocoder capable of spitting out structs and can create type definitions and specify them as measurements in packets.