### PR TITLE
Decommutation Endianess Swap Race Condition Fix

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"github.com/AarC10/GSW-V2/proc"
+	"time"
 )
 
 func printTelemetryPackets() {
@@ -58,5 +59,7 @@ func main() {
 		go proc.TestReceiver(channel)
 	}
 
-	select {}
+	time.Sleep(3 * time.Second)
+
+	//select {}
 }

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"github.com/AarC10/GSW-V2/proc"
-	"time"
 )
 
 func printTelemetryPackets() {
@@ -59,7 +58,5 @@ func main() {
 		go proc.TestReceiver(channel)
 	}
 
-	time.Sleep(3 * time.Second)
-
-	//select {}
+	select {}
 }

--- a/proc/decom.go
+++ b/proc/decom.go
@@ -66,6 +66,7 @@ func EndianessConverter(packet TelemetryPacket, inChannel chan []byte, outChanne
 	byteIndicesToSwap := make([][]int, 0)
 
 	startIndice := 0
+	packetSize := 0
 	for _, measurementName := range packet.Measurements {
 		measurement, err := FindMeasurementByName(GswConfig.Measurements, measurementName)
 		if err != nil {
@@ -78,10 +79,14 @@ func EndianessConverter(packet TelemetryPacket, inChannel chan []byte, outChanne
 		}
 
 		startIndice += measurement.Size
+		packetSize += measurement.Size
 	}
 
 	for {
-		data := <-inChannel
+		rcvData := <-inChannel
+		data := make([]byte, packetSize)
+		copy(data, rcvData)
+
 		for _, byteIndices := range byteIndicesToSwap {
 			byteSwap(data, byteIndices[0], byteIndices[1])
 		}


### PR DESCRIPTION
Ran `go run -race main.go ` to find race condition leading to resulting printed bytes to not show up properly after dealing with endianness changes.